### PR TITLE
Use `PropTypes` from `prop-types` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react-measure": "^1.4.5",
     "resize-observer-polyfill": "^1.3.1"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import getPrefix from "./get-prefix";
 import Measure from "react-measure";
 import ResizeObserver from 'resize-observer-polyfill';
@@ -27,9 +28,9 @@ export function updateAll() {
 export default class StickyBox extends React.Component {
 
   static propTypes = {
-    width: React.PropTypes.oneOfType([
-      React.PropTypes.number,
-      React.PropTypes.oneOf(["measure"])
+    width: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.oneOf(["measure"])
     ]).isRequired
   }
 


### PR DESCRIPTION
[The React maintainers deprecated using `React.PropTypes`](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes) in favor of using [an external `prop-types` package](https://github.com/facebook/prop-types). 

After starting to use `react-sticky-box` I noticed this warning popping up in my console:

![image](https://cloud.githubusercontent.com/assets/1062277/26218722/0da763f2-3bda-11e7-9446-7ef1b30ad4c0.png)

This change should remove the warning.