### PR TITLE
Implements #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ import StickyBox from "react-sticky-box";
 
   If `true`, content will stick to the bottom of viewport
 
-- **`offset={number|default: 0}`**
+- **`offset={number|array[number,number]|default: 0}`**
 
-  Defines the offset to the top of the viewport.
+  Defines the offset to the top and bottom of the viewport.
 
 - **`onChangeMode={(oldMode, newMode) => {}}`**
 

--- a/src/index.js
+++ b/src/index.js
@@ -69,19 +69,21 @@ export default class StickyBox extends React.Component {
 
   initial() {
     const {bottom, offset} = this.props;
+    const offsetTop    = Array.isArray(offset) ? offset[0] : offset;
+    const offsetBottom = Array.isArray(offset) ? offset[1] : offset;
     if (bottom) {
       if (this.mode !== "stickyBottom") {
         this.props.onChangeMode(this.mode, "stickyBottom");
         this.mode = "stickyBottom";
         this.node.style.position = stickyProp;
-        this.node.style.top = `${this.viewPortHeight - this.nodeHeight}px`;
+        this.node.style.top = `${this.viewPortHeight - this.nodeHeight - offsetBottom}px`;
       }
     } else {
       if (this.mode !== "stickyTop") {
         this.props.onChangeMode(this.mode, "stickyTop");
         this.mode = "stickyTop";
         this.node.style.position = stickyProp;
-        this.node.style.top = `${offset}px`;
+        this.node.style.top = `${offsetTop}px`;
       }
     }
   }
@@ -116,9 +118,11 @@ export default class StickyBox extends React.Component {
 
   handleScroll = () => {
     const {offset} = this.props;
+    const offsetTop    = Array.isArray(offset) ? offset[0] : offset;
+    const offsetBottom = Array.isArray(offset) ? offset[1] : offset;
     const scrollY = this.scrollPane === window ? window.scrollY : this.scrollPane.scrollTop;
     if (scrollY === this.latestScrollY) return;
-    if (this.nodeHeight + offset <= this.viewPortHeight) {
+    if (this.nodeHeight + offsetTop + offsetBottom <= this.viewPortHeight) {
       // Just make it sticky if node smaller than viewport
       this.initial();
       return;
@@ -127,33 +131,33 @@ export default class StickyBox extends React.Component {
     if (scrollDelta > 0) {
       // scroll down
       if (this.mode === "stickyTop") {
-        if (scrollY + this.scrollPaneOffset + offset > this.naturalTop) {
+        if (scrollY + this.scrollPaneOffset + offsetTop > this.naturalTop) {
           this.props.onChangeMode(this.mode, "relative");
           this.mode = "relative";
           this.node.style.position = "relative";
           this.offset = Math.max(
             0,
-            this.scrollPaneOffset + this.latestScrollY - this.naturalTop + offset
+            this.scrollPaneOffset + this.latestScrollY - this.naturalTop + offsetTop
           );
           this.node.style.top = `${this.offset}px`;
         }
       } else if (this.mode === "relative") {
         if (
           scrollY + this.scrollPaneOffset + this.viewPortHeight >
-          this.naturalTop + this.nodeHeight + this.offset
+          this.naturalTop + this.nodeHeight + this.offset + offsetBottom
         ) {
           this.props.onChangeMode(this.mode, "stickyBottom");
           this.mode = "stickyBottom";
           this.node.style.position = stickyProp;
-          this.node.style.top = `${this.viewPortHeight - this.nodeHeight}px`;
+          this.node.style.top = `${this.viewPortHeight - this.nodeHeight - offsetBottom}px`;
         }
       }
     } else {
       // scroll up
       if (this.mode === "stickyBottom") {
         if (
-          this.scrollPaneOffset + scrollY + this.viewPortHeight + offset <
-          this.naturalTop + this.parentHeight
+          this.scrollPaneOffset + scrollY + this.viewPortHeight <
+          this.naturalTop + this.parentHeight + offsetBottom
         ) {
           this.props.onChangeMode(this.mode, "relative");
           this.mode = "relative";
@@ -162,15 +166,15 @@ export default class StickyBox extends React.Component {
             this.scrollPaneOffset +
             this.latestScrollY +
             this.viewPortHeight -
-            (this.naturalTop + this.nodeHeight);
+            (this.naturalTop + this.nodeHeight + offsetBottom);
           this.node.style.top = `${this.offset}px`;
         }
       } else if (this.mode === "relative") {
-        if (this.scrollPaneOffset + scrollY + offset < this.naturalTop + this.offset) {
+        if (this.scrollPaneOffset + scrollY + offsetTop < this.naturalTop + this.offset) {
           this.props.onChangeMode(this.mode, "stickyTop");
           this.mode = "stickyTop";
           this.node.style.position = stickyProp;
-          this.node.style.top = `${offset}px`;
+          this.node.style.top = `${offsetTop}px`;
         }
       }
     }


### PR DESCRIPTION
 * Adds support for simultaneously setting top and bottom offset
 * Also fixes deadzone issue mentioned in #17.

Changes the API to support prop `offset` with either a `Number` or an `Array[2]` of `Number`s.

Add 50 pixels offset on both ends of the container:
```
<StickyBox offset={50}>
    // content
</StickyBox>
```

Set the offset at the top to 50 pixels and offset at the bottom to 200 pixels:
```
<StickyBox offset={[50, 200]}>
    // content
</StickyBox>
```

Mimic the original behaviour, where the container only has a top offset but not a bottom offset:
```
<StickyBox offset={[50, 0]}>
    // content
</StickyBox>
```