### PR TITLE
Fix this.scrollPane is undefined error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sticky-box",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Boxes that behave nicely while scrolling",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ export default class StickyBox extends React.Component {
     this.node = n;
     if (n) {
       this.scrollPane = getScrollParent(this.node);
-      this.latestScrollY = this.scrollPane === window ? window.scrollY : this.scrollPane.scrollTop;
+      this.latestScrollY = this.scrollPane === window || !this.scrollPane ? window.scrollY : this.scrollPane.scrollTop;
 
       this.scrollPane.addEventListener("scroll", this.handleScroll, passiveArg);
       this.scrollPane.addEventListener("mousewheel", this.handleScroll, passiveArg);


### PR DESCRIPTION
This line in particular is causing me a lot of problems. I'm not entirely sure if this is the correct fix, as I'm not too familiar with the code of this repo, but this fixes the issue I was having

The problem + how to recreate
===
I receive a breaking error:
```
this.scrollPane is undefined
```
when navigating from a page with a 'sticky' sidebar (using this plugin) to a page without one. It appears as if the code is still trying to read the scroll position from a div that no longer exists. As a result, our entire site crawls to a hault (CPU usage spikes) and then eventually I get this error. The fix I've submitted completely eliminates this issue for me