### PR TITLE
Update react peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.1.5",


### PR DESCRIPTION
react-sticky-box will not install in projects that use react 17 and npm 8 without using --force or --legacy-peer-deps.  This project works fine with react 17, we just need to update the peerDependencies field.