### PR TITLE
Fix types

### DIFF
--- a/packages/react-sticky-box/index.d.ts
+++ b/packages/react-sticky-box/index.d.ts
@@ -12,7 +12,15 @@ type StickyBoxCompProps = UseStickyBoxOptions & {
   children: React.ReactNode;
 };
 
-type useStickyBox = <T = any>(options?: UseStickyBoxOptions) => React.RefCallback<T>;
-type StickyBoxComp = React.FunctionComponent<StickyBoxCompProps>;
+declare function useStickyBox<T = any>(
+  options?: UseStickyBoxOptions
+): React.RefCallback<T>;
 
-export {StickyBoxComp as default, useStickyBox, StickyBoxCompProps, UseStickyBoxOptions};
+declare function StickyBoxComp(props: StickyBoxCompProps): JSX.Element;
+
+export {
+  StickyBoxComp as default,
+  useStickyBox,
+  StickyBoxCompProps,
+  UseStickyBoxOptions,
+};


### PR DESCRIPTION
Hey! Thanks for the ongoing work on `react-sticky-box` ✌️

I tried v1.0.0 and faced the same issue as described in #74.
This PR fixes the new exported types.