### PR TITLE
Added main entry point

### DIFF
--- a/packages/react-sticky-box/package.json
+++ b/packages/react-sticky-box/package.json
@@ -27,6 +27,7 @@
     "esbuild": "^0.14.25"
   },
   "type": "module",
+  "main": "./dist/index.js",
   "exports": "./dist/index.js",
   "typings": "./index.d.ts",
   "files": [


### PR DESCRIPTION
When using main entry point [node docs](https://nodejs.org/api/packages.html#main-entry-point-export) advise to define both "exports" and "main".
Without "main", storybook doesn't works.