### PR TITLE
bodyにposition: fixed が付与されている時の対応

### DIFF
--- a/packages/react-sticky-box/src/index.tsx
+++ b/packages/react-sticky-box/src/index.tsx
@@ -285,7 +285,7 @@ const setup = (node: HTMLElement, unsubs: UnsubList, opts: Required<StickyBoxCon
   changeMode(mode);
 
   const onScroll = (scrollY: number) => {
-    if (scrollY === latestScrollY) return;
+    if (scrollY === latestScrollY || document.body.style.position === "fixed") return;
     const scrollDelta = scrollY - latestScrollY;
     latestScrollY = scrollY;
     if (mode === MODES.small) return;


### PR DESCRIPTION
## 対応
- モーダル等で背景スクロールを禁止させる時に、bodyにposition: fixed を付与した時にtopの位置が変わってしまうことの対処。